### PR TITLE
Round to 2 decimals.  #54

### DIFF
--- a/sweetercat/app.py
+++ b/sweetercat/app.py
@@ -19,10 +19,10 @@ def homepage(star=None):
         idx = dfs[col].isnull()
         dfs[col] = dfs[col].astype(str)
         dfs.loc[~idx, col] = [s[:-2] for s in dfs.loc[~idx, col]]
-    for col in ('Vmag', 'Vmagerr', 'par', 'parerr', 'logg', 'loggerr',
-                'logglc', 'logglcerr', 'vt', 'vterr', 'feh', 'feherr',
-                'mass', 'masserr'):
-        dfs[col] = df[col].round(decimals=2)
+    decimals = dict.fromkeys(['Vmag', 'Vmagerr', 'par', 'parerr', 'logg',
+                              'loggerr', 'logglc', 'logglcerr', 'vterr', 'feh',
+                              'feherr', 'mass', 'masserr'], 2)
+    dfs = dfs.round(decimals=decimals)
     dfs.fillna('...', inplace=True)
     columns = dfs.columns
     dfs = dfs.loc[:, columns]

--- a/sweetercat/app.py
+++ b/sweetercat/app.py
@@ -19,6 +19,10 @@ def homepage(star=None):
         idx = dfs[col].isnull()
         dfs[col] = dfs[col].astype(str)
         dfs.loc[~idx, col] = [s[:-2] for s in dfs.loc[~idx, col]]
+    for col in ('Vmag', 'Vmagerr', 'par', 'parerr', 'logg', 'loggerr',
+                'logglc', 'logglcerr', 'vt', 'vterr', 'feh', 'feherr',
+                'mass', 'masserr'):
+        dfs[col] = df[col].round(decimals=2)
     dfs.fillna('...', inplace=True)
     columns = dfs.columns
     dfs = dfs.loc[:, columns]

--- a/sweetercat/tests/test_app.py
+++ b/sweetercat/tests/test_app.py
@@ -140,3 +140,10 @@ def test_error_404(client):
     assert b'This page could not be found' in error404.data
     assert b'Our space monkeys are working on the issue...' in error404.data
     assert b'<img src="static/spacemonkey.png" alt="">' in error404.data
+
+
+def test_issue54_rounding(client):
+    """Check that the troublesome values are removed."""
+    homepage = client.get(url_for("homepage"))
+    for number in ['4.34399999999999', '14.386']:
+        assert number.encode('utf-8') not in homepage.data


### PR DESCRIPTION
#54 This rounds all the data columns except `teff `and `tefferr` which are to be `int`, to 2 dp.

It could also have been done as
```
decimals = {'Vmag': 2, 'Vmagerr': 2, 'par': 2, 'parerr': 2, 'logg': 2, 'loggerr': 2,
+                'logglc': 2, 'logglcerr': 2, 'vt': 2, 'vterr': 2, 'feh': 2, 'feherr': 2,
+                'mass': 2, 'masserr': 2}
dfs = dfs.round(decimals)
```
maybe in `inplace=True` would also work
`dfs.round(decimals, inplace=True)`
At the time I didn't want to repeat all the 2's but seeing this here it may be better then using the for loop.
Do you have a preference?