### PR TITLE
Remove python 2.7 from travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 


### PR DESCRIPTION
I do not know if there are any other things that need changed.

Basically we do not test python 2.7 anymore. #108 
