### PR TITLE
Remove conda from travis-ci. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,8 @@ python:
   - "3.5"
   - "3.6"
 
-# Setup anaconda
 before_install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      travis_retry wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
-
-  # https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
+    # https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"  # xvfb = Virtual frame buffer
   - sleep 3                         # give xvfb some time to start
@@ -27,9 +14,7 @@ cache:
     - $HOME/.cache/pip
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-  # - python setup.py install
+    # - python setup.py install
   - travis_retry pip install -r requirements.txt
 
   # Testing requirements


### PR DESCRIPTION
We don't use any conda specific packages (anymore).

Conda installs a series of packages which can interfere with the versions we want to install. 
e.g. currently this is `certifi`

This is even faster to test as (by ~1 min) as we don't install conda and create a new environment.

Travis will still use a python `virtualenv` to set everything up in.