### PR TITLE
Run tests on columns of the database.

### DIFF
--- a/sweetercat/tests/test_data.py
+++ b/sweetercat/tests/test_data.py
@@ -1,0 +1,29 @@
+# Test properties of the sweet-cat database
+
+def test_all_have_star_name(SCdata):
+    # Test every entry has a "Star" name
+    df, _ = SCdata
+    assert not df.Star.isnull().values.any()
+
+
+def test_all_have_link(SCdata):
+    # Test each entry has an associated author/paper.
+    df, _ = SCdata
+    null_links = df.link.isnull()
+    # Printing is for idenifying missing links on failure only
+    print("Stars with missing links:\n")
+    for star in df.Star[null_links].values:
+        print(star)
+    assert not null_links.values.any()
+
+
+def test_all_have_Author(SCdata):
+    # Test each entry has an associated link to paper.
+    df, _ = SCdata
+
+    null_author = df.Author.isnull()
+    # Printing is for idenifying missing author on failure only.
+    print("Stars with missing Author:")
+    for star in df.Star[null_author].values:
+        print(star)
+    assert not null_author.values.any()


### PR DESCRIPTION
Quoting @DanielAndreasen  from #135 
> I think it is right that the build failed, since we should have a reference for the parameters.

This adds specific tests regarding the database the will fail the build if there is `NULL` in specific columns. We "should" have a `Star` name, an `Author` and a `link` to the paper.
The tests prints on failure to easily identify which `Author`s and `link`s are missing.

Are there any other columns that "should" be checked like this?

One could other be that the homogeneous flag is either 0 or 1  (and not NULL)
 